### PR TITLE
Use helper function to get class name for various class members

### DIFF
--- a/hotdoc_gi_extension/gi_extension.py
+++ b/hotdoc_gi_extension/gi_extension.py
@@ -283,22 +283,22 @@ class GIExtension(BaseExtension):
         for node in gir_root.xpath(
                 './/core:property',
                 namespaces=self.__nsmap):
-            name = '%s:%s' % (node.getparent().attrib['{%s}type' %
-                self.__nsmap['c']], node.attrib['name'])
+            name = '%s:%s' % (self.__get_klass_name(node.getparent()),
+                              node.attrib['name'])
             self.__node_cache[name] = node
 
         for node in gir_root.xpath(
                 './/glib:signal',
                 namespaces=self.__nsmap):
-            name = '%s::%s' % (node.getparent().attrib['{%s}type' %
-                self.__nsmap['c']], node.attrib['name'])
+            name = '%s::%s' % (self.__get_klass_name(node.getparent()),
+                               node.attrib['name'])
             self.__node_cache[name] = node
 
         for node in gir_root.xpath(
                 './/core:virtual-method',
                 namespaces=self.__nsmap):
-            name = '%s:::%s' % (node.getparent().attrib['{%s}type' %
-                self.__nsmap['c']], node.attrib['name'])
+            name = '%s:::%s' % (self.__get_klass_name(node.getparent()),
+                                node.attrib['name'])
             self.__node_cache[name] = node
 
         for inc in gir_root.findall('./core:include',


### PR DESCRIPTION
Many GIR files do not have c:type attributes on <class/> or <interface/>
elements (in fact, only those generated by Vala, on my system, seem to
have them, although gobject-introspection’s GI writer does have support
for them). Hence, the code here cannot rely on the c:type attribute
existing, or it will get key errors.

Use the existing helper function which tries c:type then calls back to
glib:type-name instead.
